### PR TITLE
Potential fix for code scanning alert no. 13: DOM text reinterpreted as HTML

### DIFF
--- a/apps/client/src/entities/recording/api.ts
+++ b/apps/client/src/entities/recording/api.ts
@@ -75,5 +75,16 @@ export const getRecordingStreamUrl = (
   serverUrl: string,
   token: string
 ): string => {
-  return `${serverUrl}/api/recordings/${id}/stream?token=${token}`;
+  try {
+    const baseUrl = new URL(serverUrl);
+    if (baseUrl.protocol !== "http:" && baseUrl.protocol !== "https:") {
+      return "";
+    }
+
+    const streamUrl = new URL(`/api/recordings/${id}/stream`, baseUrl.origin);
+    streamUrl.searchParams.set("token", token);
+    return streamUrl.toString();
+  } catch {
+    return "";
+  }
 };

--- a/apps/client/src/features/auth/index.tsx
+++ b/apps/client/src/features/auth/index.tsx
@@ -15,6 +15,20 @@ import { parseJwt } from "@/lib/jwt";
 
 const MAX_RECENT_URLS = 5;
 
+function sanitizeServerUrl(rawUrl: string): string | null {
+  const trimmed = rawUrl.trim().replace(/\/$/, "");
+
+  try {
+    const parsed = new URL(trimmed);
+    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+      return null;
+    }
+    return parsed.origin;
+  } catch {
+    return null;
+  }
+}
+
 export function LoginForm({
   className,
   ...props
@@ -109,7 +123,13 @@ export function LoginForm({
   const handleAuth = async (e: React.FormEvent) => {
     e.preventDefault();
     setIsLoading(true);
-    const processedUrl = url.replace(/\/$/, "");
+    const processedUrl = sanitizeServerUrl(url);
+
+    if (!processedUrl) {
+      toast.error("Please enter a valid server URL using http or https.");
+      setIsLoading(false);
+      return;
+    }
 
     try {
       const token = await authenticateWithPassword(processedUrl, {


### PR DESCRIPTION
Potential fix for [https://github.com/cartesiancs/vessel/security/code-scanning/13](https://github.com/cartesiancs/vessel/security/code-scanning/13)

To fix this without changing intended functionality, validate and normalize server URLs to allow only `http:` and `https:` origins, then use only the sanitized value when storing and when constructing stream URLs.

Best single approach in current snippets:
1. **In `apps/client/src/features/auth/index.tsx`**: sanitize `processedUrl` in `handleAuth` before `storage.setServerUrl(...)`. Reject invalid/non-http(s) URLs and show an error toast.
2. **In `apps/client/src/entities/recording/api.ts`**: harden `getRecordingStreamUrl` by parsing `serverUrl` with `new URL(...)`, enforcing protocol allowlist, and building the final URL via URL APIs (including encoded token) instead of string concatenation. Return empty string for invalid input so callers naturally skip rendering (`streamUrl ? ... : ...`).
3. **In `apps/client/src/features/recording/VideoPlaybackDialog.tsx`**: no logic rewrite needed beyond relying on safe URL construction; existing `streamUrl ? ... : ...` behavior already handles empty/invalid return.

No new dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
